### PR TITLE
docs: Link to active repository pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Observe the result of this Push:
 
 [post]: https://medium.com/p/f594c21373ef
 [post/deploy-keys]: https://medium.com/p/f594c21373ef#7a8c
-[fork]: fork
-[enable-actions]: actions
+[fork]: /fork
+[enable-actions]: /actions
 [workflows/prettify]: .github/workflows/prettify.yml
 [prettier]: https://prettier.io/
 [prettier/quotes]: https://prettier.io/docs/en/rationale.html


### PR DESCRIPTION
The relative links (`actions` and `fork`) are treated as actual relative links (i.e: relative to the current page) so the documentation needs to use absolute links (`/actions`, `/fork`) which GitHub's Markdown parser will transform to repository relative links.