### PR TITLE
docs: Add relative path to repository pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Observe the result of this Push:
 
 [post]: https://medium.com/p/f594c21373ef
 [post/deploy-keys]: https://medium.com/p/f594c21373ef#7a8c
-[fork]: /fork
-[enable-actions]: /actions
+[fork]: ../../fork
+[enable-actions]: ../../actions
 [workflows/prettify]: .github/workflows/prettify.yml
 [prettier]: https://prettier.io/
 [prettier/quotes]: https://prettier.io/docs/en/rationale.html


### PR DESCRIPTION
My reasoning behind #2 was wrong, relative paths are relative to the current branch so we need to explicitly provide a reference to the path relative to the branch -- which is two levels above.

From https://github.com/pr-mpt/examples-workflow-trigger/tree/main:

```
../../fork -> https://github.com/pr-mpt/examples-workflow-trigger/fork
```